### PR TITLE
[Feat] 사용자 정보, 로그인상태 테스트 로직 구현

### DIFF
--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeon.xcodeproj/project.pbxproj
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeon.xcodeproj/project.pbxproj
@@ -9,12 +9,18 @@
 /* Begin PBXBuildFile section */
 		182BF0DD2D85886B00C7B308 /* KeyChainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0DC2D85886B00C7B308 /* KeyChainHelper.swift */; };
 		182BF0E52D8595B800C7B308 /* UserInfoCoreData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0E32D8595B800C7B308 /* UserInfoCoreData.xcdatamodeld */; };
-		182BF0E72D85985200C7B308 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0E62D85985200C7B308 /* LoginView.swift */; };
-		182BF0EA2D85A46100C7B308 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0E92D85A46100C7B308 /* LoginViewModel.swift */; };
+		182BF0E72D85985200C7B308 /* LoginSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0E62D85985200C7B308 /* LoginSuccessView.swift */; };
+		182BF0EA2D85A46100C7B308 /* LoginSuccessViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0E92D85A46100C7B308 /* LoginSuccessViewModel.swift */; };
 		182BF0ED2D85AE1B00C7B308 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0EC2D85AE1B00C7B308 /* UserDefaultsManager.swift */; };
+		182BF0F82D86581400C7B308 /* SignUpError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0F72D86581400C7B308 /* SignUpError.swift */; };
+		182BF0FA2D8662B900C7B308 /* KeyChainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0F92D8662B900C7B308 /* KeyChainError.swift */; };
+		182BF0FC2D86630300C7B308 /* CoreDataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF0FB2D86630300C7B308 /* CoreDataError.swift */; };
+		182BF1042D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 182BF1032D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.swift */; };
+		182BF10B2D86672D00C7B308 /* RxBlocking in Frameworks */ = {isa = PBXBuildFile; productRef = 182BF10A2D86672D00C7B308 /* RxBlocking */; };
+		182BF10D2D86672D00C7B308 /* RxTest in Frameworks */ = {isa = PBXBuildFile; productRef = 182BF10C2D86672D00C7B308 /* RxTest */; };
 		1895FD542D83F7A400BB644B /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = 1895FD532D83F7A400BB644B /* RxCocoa */; };
 		1895FD562D83F7A400BB644B /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 1895FD552D83F7A400BB644B /* RxSwift */; };
-		1895FD592D83F7C700BB644B /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1895FD582D83F7C700BB644B /* LoginViewController.swift */; };
+		1895FD592D83F7C700BB644B /* LoginSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1895FD582D83F7C700BB644B /* LoginSuccessViewController.swift */; };
 		1895FD5E2D840CDC00BB644B /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1895FD5D2D840CDC00BB644B /* SignUpViewController.swift */; };
 		1895FD602D840D4700BB644B /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1895FD5F2D840D4700BB644B /* SignUpView.swift */; };
 		1895FD622D840F9F00BB644B /* CustomInputTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1895FD612D840F9F00BB644B /* CustomInputTextField.swift */; };
@@ -36,13 +42,36 @@
 		18CE483B2D83F140003A2E7D /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CE483A2D83F140003A2E7D /* UIColor+Extension.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		182BF1052D8666ED00C7B308 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 18CE48072D82B128003A2E7D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18CE480E2D82B128003A2E7D;
+			remoteInfo = LoginSystem_ParkSiYeon;
+		};
+		182BF1162D86679800C7B308 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 18CE48072D82B128003A2E7D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18CE480E2D82B128003A2E7D;
+			remoteInfo = LoginSystem_ParkSiYeon;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		182BF0DC2D85886B00C7B308 /* KeyChainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainHelper.swift; sourceTree = "<group>"; };
 		182BF0E42D8595B800C7B308 /* UserInfoCoreData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = UserInfoCoreData.xcdatamodel; sourceTree = "<group>"; };
-		182BF0E62D85985200C7B308 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		182BF0E92D85A46100C7B308 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		182BF0E62D85985200C7B308 /* LoginSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSuccessView.swift; sourceTree = "<group>"; };
+		182BF0E92D85A46100C7B308 /* LoginSuccessViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSuccessViewModel.swift; sourceTree = "<group>"; };
 		182BF0EC2D85AE1B00C7B308 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
-		1895FD582D83F7C700BB644B /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		182BF0F72D86581400C7B308 /* SignUpError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpError.swift; sourceTree = "<group>"; };
+		182BF0F92D8662B900C7B308 /* KeyChainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChainError.swift; sourceTree = "<group>"; };
+		182BF0FB2D86630300C7B308 /* CoreDataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataError.swift; sourceTree = "<group>"; };
+		182BF1012D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LoginSystem_ParkSiYeonTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		182BF1032D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSystem_ParkSiYeonTests.swift; sourceTree = "<group>"; };
+		182BF1122D86679800C7B308 /* StartViewModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StartViewModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1895FD582D83F7C700BB644B /* LoginSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSuccessViewController.swift; sourceTree = "<group>"; };
 		1895FD5D2D840CDC00BB644B /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		1895FD5F2D840D4700BB644B /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		1895FD612D840F9F00BB644B /* CustomInputTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomInputTextField.swift; sourceTree = "<group>"; };
@@ -67,6 +96,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		182BF0FE2D8666ED00C7B308 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				182BF10D2D86672D00C7B308 /* RxTest in Frameworks */,
+				182BF10B2D86672D00C7B308 /* RxBlocking in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		182BF10F2D86679800C7B308 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18CE480C2D82B128003A2E7D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -88,12 +133,12 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
-		182BF0E82D85A45400C7B308 /* LoginViewModel */ = {
+		182BF0E82D85A45400C7B308 /* LoginSuccessViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				182BF0E92D85A46100C7B308 /* LoginViewModel.swift */,
+				182BF0E92D85A46100C7B308 /* LoginSuccessViewModel.swift */,
 			);
-			path = LoginViewModel;
+			path = LoginSuccessViewModel;
 			sourceTree = "<group>";
 		};
 		182BF0EB2D85AE0200C7B308 /* Managers */ = {
@@ -105,14 +150,32 @@
 			path = Managers;
 			sourceTree = "<group>";
 		};
-		1895FD572D83F7B500BB644B /* Login */ = {
+		182BF0F62D86573500C7B308 /* Error */ = {
 			isa = PBXGroup;
 			children = (
-				182BF0E82D85A45400C7B308 /* LoginViewModel */,
-				182BF0E62D85985200C7B308 /* LoginView.swift */,
-				1895FD582D83F7C700BB644B /* LoginViewController.swift */,
+				182BF0F72D86581400C7B308 /* SignUpError.swift */,
+				182BF0F92D8662B900C7B308 /* KeyChainError.swift */,
+				182BF0FB2D86630300C7B308 /* CoreDataError.swift */,
 			);
-			path = Login;
+			path = Error;
+			sourceTree = "<group>";
+		};
+		182BF1022D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests */ = {
+			isa = PBXGroup;
+			children = (
+				182BF1032D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.swift */,
+			);
+			path = LoginSystem_ParkSiYeonTests;
+			sourceTree = "<group>";
+		};
+		1895FD572D83F7B500BB644B /* LoginSuccess */ = {
+			isa = PBXGroup;
+			children = (
+				182BF0E82D85A45400C7B308 /* LoginSuccessViewModel */,
+				182BF0E62D85985200C7B308 /* LoginSuccessView.swift */,
+				1895FD582D83F7C700BB644B /* LoginSuccessViewController.swift */,
+			);
+			path = LoginSuccess;
 			sourceTree = "<group>";
 		};
 		1895FD5C2D840CCA00BB644B /* SignUp */ = {
@@ -148,6 +211,7 @@
 			isa = PBXGroup;
 			children = (
 				18CE48112D82B128003A2E7D /* LoginSystem_ParkSiYeon */,
+				182BF1022D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests */,
 				18CE48102D82B128003A2E7D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -156,6 +220,8 @@
 			isa = PBXGroup;
 			children = (
 				18CE480F2D82B128003A2E7D /* LoginSystem_ParkSiYeon.app */,
+				182BF1012D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.xctest */,
+				182BF1122D86679800C7B308 /* StartViewModelTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -166,6 +232,7 @@
 				1895FD6F2D85756F00BB644B /* LoginSystem_ParkSiYeon.entitlements */,
 				18CE48292D82CB50003A2E7D /* Support */,
 				18CE482B2D82CC2B003A2E7D /* CoreData */,
+				182BF0F62D86573500C7B308 /* Error */,
 				18CE48362D83EB4D003A2E7D /* Utils */,
 				18CE482C2D82CC36003A2E7D /* Screen */,
 				18CE482A2D82CB9E003A2E7D /* Resource */,
@@ -205,7 +272,7 @@
 			children = (
 				18CE482D2D82CC3C003A2E7D /* Start */,
 				1895FD5C2D840CCA00BB644B /* SignUp */,
-				1895FD572D83F7B500BB644B /* Login */,
+				1895FD572D83F7B500BB644B /* LoginSuccess */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -252,6 +319,46 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		182BF1002D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 182BF1092D8666ED00C7B308 /* Build configuration list for PBXNativeTarget "LoginSystem_ParkSiYeonTests" */;
+			buildPhases = (
+				182BF0FD2D8666ED00C7B308 /* Sources */,
+				182BF0FE2D8666ED00C7B308 /* Frameworks */,
+				182BF0FF2D8666ED00C7B308 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				182BF1062D8666ED00C7B308 /* PBXTargetDependency */,
+			);
+			name = LoginSystem_ParkSiYeonTests;
+			packageProductDependencies = (
+				182BF10A2D86672D00C7B308 /* RxBlocking */,
+				182BF10C2D86672D00C7B308 /* RxTest */,
+			);
+			productName = LoginSystem_ParkSiYeonTests;
+			productReference = 182BF1012D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		182BF1112D86679800C7B308 /* StartViewModelTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 182BF1182D86679800C7B308 /* Build configuration list for PBXNativeTarget "StartViewModelTests" */;
+			buildPhases = (
+				182BF10E2D86679800C7B308 /* Sources */,
+				182BF10F2D86679800C7B308 /* Frameworks */,
+				182BF1102D86679800C7B308 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				182BF1172D86679800C7B308 /* PBXTargetDependency */,
+			);
+			name = StartViewModelTests;
+			productName = StartViewModelTests;
+			productReference = 182BF1122D86679800C7B308 /* StartViewModelTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		18CE480E2D82B128003A2E7D /* LoginSystem_ParkSiYeon */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 18CE48262D82B12B003A2E7D /* Build configuration list for PBXNativeTarget "LoginSystem_ParkSiYeon" */;
@@ -284,6 +391,14 @@
 				LastSwiftUpdateCheck = 1540;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
+					182BF1002D8666ED00C7B308 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 18CE480E2D82B128003A2E7D;
+					};
+					182BF1112D86679800C7B308 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 18CE480E2D82B128003A2E7D;
+					};
 					18CE480E2D82B128003A2E7D = {
 						CreatedOnToolsVersion = 15.4;
 					};
@@ -307,11 +422,27 @@
 			projectRoot = "";
 			targets = (
 				18CE480E2D82B128003A2E7D /* LoginSystem_ParkSiYeon */,
+				182BF1002D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests */,
+				182BF1112D86679800C7B308 /* StartViewModelTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		182BF0FF2D8666ED00C7B308 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		182BF1102D86679800C7B308 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18CE480D2D82B128003A2E7D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -324,11 +455,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		182BF0FD2D8666ED00C7B308 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				182BF1042D8666ED00C7B308 /* LoginSystem_ParkSiYeonTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		182BF10E2D86679800C7B308 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		18CE480B2D82B128003A2E7D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1895FD592D83F7C700BB644B /* LoginViewController.swift in Sources */,
+				1895FD592D83F7C700BB644B /* LoginSuccessViewController.swift in Sources */,
 				1895FD622D840F9F00BB644B /* CustomInputTextField.swift in Sources */,
 				1895FD6C2D8566F000BB644B /* SignUpViewModel.swift in Sources */,
 				18CE48172D82B128003A2E7D /* StartViewController.swift in Sources */,
@@ -340,20 +486,36 @@
 				1895FD5E2D840CDC00BB644B /* SignUpViewController.swift in Sources */,
 				1895FD6E2D8570A100BB644B /* String+Extension.swift in Sources */,
 				1895FD662D841F9D00BB644B /* CustomInputView.swift in Sources */,
+				182BF0FC2D86630300C7B308 /* CoreDataError.swift in Sources */,
+				182BF0FA2D8662B900C7B308 /* KeyChainError.swift in Sources */,
 				1895FD602D840D4700BB644B /* SignUpView.swift in Sources */,
 				18CE482F2D83C8C7003A2E7D /* StartView.swift in Sources */,
+				182BF0F82D86581400C7B308 /* SignUpError.swift in Sources */,
 				1895FD712D85815100BB644B /* UserInfoCoreDataManager.swift in Sources */,
 				18CE48132D82B128003A2E7D /* AppDelegate.swift in Sources */,
 				1895FD642D841BCF00BB644B /* UIStackView+Extension.swift in Sources */,
-				182BF0EA2D85A46100C7B308 /* LoginViewModel.swift in Sources */,
+				182BF0EA2D85A46100C7B308 /* LoginSuccessViewModel.swift in Sources */,
 				18CE48152D82B128003A2E7D /* SceneDelegate.swift in Sources */,
 				18CE483B2D83F140003A2E7D /* UIColor+Extension.swift in Sources */,
-				182BF0E72D85985200C7B308 /* LoginView.swift in Sources */,
+				182BF0E72D85985200C7B308 /* LoginSuccessView.swift in Sources */,
 				182BF0DD2D85886B00C7B308 /* KeyChainHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		182BF1062D8666ED00C7B308 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 18CE480E2D82B128003A2E7D /* LoginSystem_ParkSiYeon */;
+			targetProxy = 182BF1052D8666ED00C7B308 /* PBXContainerItemProxy */;
+		};
+		182BF1172D86679800C7B308 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 18CE480E2D82B128003A2E7D /* LoginSystem_ParkSiYeon */;
+			targetProxy = 182BF1162D86679800C7B308 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		18CE48202D82B12B003A2E7D /* LaunchScreen.storyboard */ = {
@@ -367,6 +529,82 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		182BF1072D8666ED00C7B308 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5Y43RDX3FM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sy0201.LoginSystem-ParkSiYeonTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LoginSystem_ParkSiYeon.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LoginSystem_ParkSiYeon";
+			};
+			name = Debug;
+		};
+		182BF1082D8666ED00C7B308 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5Y43RDX3FM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.sy0201.LoginSystem-ParkSiYeonTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LoginSystem_ParkSiYeon.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LoginSystem_ParkSiYeon";
+			};
+			name = Release;
+		};
+		182BF1192D86679800C7B308 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5Y43RDX3FM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sy0201.StartViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LoginSystem_ParkSiYeon.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LoginSystem_ParkSiYeon";
+			};
+			name = Debug;
+		};
+		182BF11A2D86679800C7B308 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5Y43RDX3FM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sy0201.StartViewModelTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LoginSystem_ParkSiYeon.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LoginSystem_ParkSiYeon";
+			};
+			name = Release;
+		};
 		18CE48242D82B12B003A2E7D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -559,6 +797,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		182BF1092D8666ED00C7B308 /* Build configuration list for PBXNativeTarget "LoginSystem_ParkSiYeonTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				182BF1072D8666ED00C7B308 /* Debug */,
+				182BF1082D8666ED00C7B308 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		182BF1182D86679800C7B308 /* Build configuration list for PBXNativeTarget "StartViewModelTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				182BF1192D86679800C7B308 /* Debug */,
+				182BF11A2D86679800C7B308 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		18CE480A2D82B128003A2E7D /* Build configuration list for PBXProject "LoginSystem_ParkSiYeon" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -599,6 +855,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		182BF10A2D86672D00C7B308 /* RxBlocking */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1895FD522D83F7A400BB644B /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxBlocking;
+		};
+		182BF10C2D86672D00C7B308 /* RxTest */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 1895FD522D83F7A400BB644B /* XCRemoteSwiftPackageReference "RxSwift" */;
+			productName = RxTest;
+		};
 		1895FD532D83F7A400BB644B /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 1895FD522D83F7A400BB644B /* XCRemoteSwiftPackageReference "RxSwift" */;

--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/CoreDataManagerTests.swift
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/CoreDataManagerTests.swift
@@ -1,0 +1,26 @@
+//
+//  CoreDataManagerTests.swift
+//  LoginSystem_ParkSiYeonTests
+//
+//  Created by siyeon park on 3/16/25.
+//
+
+import XCTestCase
+
+class CoreDataManagerTests: XCTestCase {
+    var coreDataManager: MockCoreDataManager!
+    
+    override func setUp() {
+        coreDataManager = MockCoreDataManager()
+    }
+    
+    func testSaveUserInfo() throws {
+        try coreDataManager.saveUserInfo(email: "test@example.com", password: "password", nickname: "nickname")
+        XCTAssertTrue(coreDataManager.isEmailAlreadyExists(email: "test@example.com"))
+    }
+    
+    func testSaveUserInfoWithError() {
+        coreDataManager.shouldThrowOnSave = true
+        XCTAssertThrowsError(try coreDataManager.saveUserInfo(email: "test@example.com", password: "password", nickname: "nickname"))
+    }
+}

--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/LoginSystem_ParkSiYeonTests.swift
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/LoginSystem_ParkSiYeonTests.swift
@@ -1,0 +1,34 @@
+//
+//  LoginSystem_ParkSiYeonTests.swift
+//  LoginSystem_ParkSiYeonTests
+//
+//  Created by siyeon park on 3/16/25.
+//
+
+import XCTest
+
+final class LoginSystem_ParkSiYeonTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+}

--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/Mock/MockCoreDataManager.swift
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/Mock/MockCoreDataManager.swift
@@ -1,0 +1,30 @@
+//
+//  MockCoreDataManager.swift
+//  LoginSystem_ParkSiYeonTests
+//
+//  Created by siyeon park on 3/16/25.
+//
+
+import XCTest
+
+// CoreDataManagerProtocol.swift
+protocol CoreDataManagerProtocol {
+    func isEmailAlreadyExists(email: String) -> Bool
+    func saveUserInfo(email: String, password: String, nickname: String) throws
+}
+
+class MockCoreDataManager: CoreDataManagerProtocol {
+    var storedEmails: [String] = []
+    var shouldThrowOnSave = false
+
+    func isEmailAlreadyExists(email: String) -> Bool {
+        return storedEmails.contains(email)
+    }
+
+    func saveUserInfo(email: String, password: String, nickname: String) throws {
+        if shouldThrowOnSave {
+            throw NSError(domain: "MockCoreDataError", code: 1, userInfo: nil)
+        }
+        storedEmails.append(email)
+    }
+}

--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/Mock/MockUserDefaultsManager.swift
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/Mock/MockUserDefaultsManager.swift
@@ -1,0 +1,37 @@
+//
+//  MockUserDefaultsManager.swift
+//  StartViewModelTests
+//
+//  Created by siyeon park on 3/16/25.
+//
+
+import XCTest
+
+protocol UserDefaultsManagerProtocol {
+    func getUserLoggedIn() -> Bool
+    func saveUserLoggedIn(_ value: Bool)
+    func saveNickname(_ nickname: String)
+    func saveUserEmail(_ email: String)
+}
+
+class MockUserDefaultsManager: UserDefaultsManagerProtocol {
+    var loggedIn = false
+    var nickname = ""
+    var email = ""
+    
+    func getUserLoggedIn() -> Bool {
+        return loggedIn
+    }
+    
+    func saveUserLoggedIn(_ value: Bool) {
+        loggedIn = value
+    }
+    
+    func saveNickname(_ value: String) {
+        nickname = value
+    }
+    
+    func saveUserEmail(_ value: String) {
+        email = value
+    }
+}

--- a/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/UserDefaultsManagerTests.swift
+++ b/LoginSystem_ParkSiYeon/LoginSystem_ParkSiYeonTests/UserDefaultsManagerTests.swift
@@ -1,0 +1,21 @@
+//
+//  UserDefaultsManagerTests.swift
+//  LoginSystem_ParkSiYeonTests
+//
+//  Created by siyeon park on 3/16/25.
+//
+
+import XCTest
+
+class UserDefaultsManagerTests: XCTestCase {
+    var userDefaultsManager: MockUserDefaultsManager!
+
+    override func setUp() {
+        userDefaultsManager = MockUserDefaultsManager()
+    }
+
+    func testSaveAndGetLoginStatus() {
+        userDefaultsManager.saveUserLoggedIn(true)
+        XCTAssertTrue(userDefaultsManager.getUserLoggedIn())
+    }
+}


### PR DESCRIPTION
## 1. 요약 
- Mock 객체: Core Data Manager와 User Defaults Manager에 대해 Mock 객체를 사용하여 의존성을 분리
- CoreDataManagerTests: 사용자 정보를 저장하고, 중복 이메일 여부를 확인하는 로직을 검증
- UserDefaultsManagerTests: 로그인 상태를 저장하고, 올바르게 가져오는지 검증
## 2. 스크린샷 
## 3. 공유사항
